### PR TITLE
Potential fix for code scanning alert no. 1: Disabled TLS certificate check

### DIFF
--- a/provider/ns1/ns1.go
+++ b/provider/ns1/ns1.go
@@ -129,7 +129,7 @@ func newNS1ProviderWithHTTPClient(config NS1Config, client *http.Client) (*NS1Pr
 			IdleConnTimeout:       defaultTransport.IdleConnTimeout,
 			ExpectContinueTimeout: defaultTransport.ExpectContinueTimeout,
 			TLSHandshakeTimeout:   defaultTransport.TLSHandshakeTimeout,
-			TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig:       &tls.Config{},
 		}
 		client.Transport = tr
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/AndrewCharlesHay/external-dns/security/code-scanning/1](https://github.com/AndrewCharlesHay/external-dns/security/code-scanning/1)

To fix the problem, we need to ensure that TLS certificate verification is not disabled in production code. Instead of setting `InsecureSkipVerify` to `true`, we should configure the application to use valid certificates. This can be achieved by removing the `InsecureSkipVerify` setting and ensuring that the application uses proper certificate validation.

1. Remove the `InsecureSkipVerify: true` line from the TLS configuration.
2. Ensure that the application is configured to use valid certificates.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
